### PR TITLE
Farbzuweisungen in Techniken / Focus geändert

### DIFF
--- a/content/02-archiv/200-techniken/36-focus/focus.txt
+++ b/content/02-archiv/200-techniken/36-focus/focus.txt
@@ -35,12 +35,12 @@ Ein Beispiel:
 ```css
 
 a {
-	color: #900;
+	color: #1E90FF;
 	text-decoration: underline;
 }
 
 a:hover, a:focus {
-	color: #090;
+	color: #2F4F4F;
 }
 ```
 


### PR DESCRIPTION
Ein Wechsel von rot auf grün ist auf einer Seite zu Barrierefreiheit eventuell nicht die beste Idee.
